### PR TITLE
Auto-Automatch players no longer insist on being the host.

### DIFF
--- a/src/ext/automatch.js
+++ b/src/ext/automatch.js
@@ -631,14 +631,11 @@ loadAutomatchModule = function (gs, conn, mtgRoom, zch) {
         if ((m = tName.toLowerCase().match(/for\s*\S*/)) !== null) {
             console.log('Table is for a specific opp; no automatch');
         } else {
-            var np, hn, rs, ar;
+            var np, rs, ar;
 
             np = {rclass: 'NumPlayers', props: {}};
             np.props.min_players = pCount;
             np.props.max_players = pCount;
-
-            hn = {rclass: 'HostName', props: {}};
-            hn.props.hostname = gs.AM.player.pname;
 
             rs = {rclass: 'RatingSystem', props: {}};
             rs.props.rating_system = rSystem;
@@ -651,7 +648,7 @@ loadAutomatchModule = function (gs, conn, mtgRoom, zch) {
             // Send seek request
             var seek = {
                 player: gs.AM.player,
-                requirements: [np, hn, rs, ar]
+                requirements: [np, rs, ar]
             };
             console.log(seek);
 


### PR DESCRIPTION
Tiny change, but I think it's a big enough deal to include in this release.

For the sake of the users who don't currently use or understand automatch, I originally planned auto-automatch to just bring your matched opponent to your game. But that doesn't always work with because of the 50-person lobbies, so instead I made it send both players to Outpost anyway.

Since I'm already doing that, I might as well remove the restriction that auto-auto only creates matches where you (the auto-auto user) are the host. That way two auto-auto users can match each other, and a match between an auto-auto and regular automatch user doesn't have to settle for having the auto-auto user as host if the opponent has more cards.

So I think it'll generate more matches and improve their quality. I haven't been testing with this, but it's such a small change that I'm not very worried.
