### PR TITLE
Fix bug in Vineyard VP counting

### DIFF
--- a/src/ext/vpcounter.js
+++ b/src/ext/vpcounter.js
@@ -76,7 +76,7 @@
             case 'Vineyard':
                 var actionCardCount = 0;
                 for (cname in deck) {
-                    if (gokoCardData(cname).type.match(/action/)) {
+                    if (gokoCardData(cname).type.match(/(^|[^e])action/)) {
                         actionCardCount += deck[cname];
                     }
                 }


### PR DESCRIPTION
Now instead of matching "action", we must match "action" when it is either at the start of the string, or not preceded by an "e" character. Ideally we would use negative lookbehind, but Javascript doesn't support that, so instead I used this imperfect solution; it would break if Goko's card database happened to store the card types all mashed together as one big string, with no separators between multi-type designators (eg if there were a "treasureaction" card), but I think on the real-world Goko data it is probably fine.

Apologies for not testing this first; I'm not set up to test Chrome extensions.
