### PR TITLE
Don't send empty chat messages

### DIFF
--- a/src/ext/chatbox.js
+++ b/src/ext/chatbox.js
@@ -35,7 +35,9 @@
                 e.preventDefault();
                 var text = $('#chatline').val();
                 $('#chatline').val('');
-                GS.sendRoomChat(text);
+                if (text) {
+                    GS.sendRoomChat(text);
+                }
             }
         });
 


### PR DESCRIPTION
If I press Enter while the chatbox is empty, I don't mean to send an empty message: it's just a reflex from chatboxes that require you to press Enter to open them.
