### PR TITLE
Allow whitespace after rating ranges

### DIFF
--- a/src/ext/utils.js
+++ b/src/ext/utils.js
@@ -130,15 +130,12 @@
 
         if ((m = tablename.match(/^(.* |)(\d+(.\d+)?([kK])?)\+/)) !== null) {
             range.min = GS.parseNum(m[2]);
-        }
-        if ((m = tablename.match(/^(.* |)(\d+(.\d+)?([kK])?)-(\d+(.\d+)?([kK])?)/)) !== null) {
+        } else if ((m = tablename.match(/^(.* |)(\d+(.\d+)?([kK])?)-(\d+(.\d+)?([kK])?)/)) !== null) {
             range.min = GS.parseNum(m[2]);
             range.max = GS.parseNum(m[5]);
-        }
-        if ((m = tablename.match(/^(.* |)(\d+(.\d+)?([kK])?)\-/)) !== null) {
+        } else if ((m = tablename.match(/^(.* |)(\d+(.\d+)?([kK])?)\-/)) !== null) {
             range.max = GS.parseNum(m[2]);
-        }
-        if ((m = tablename.match(/^(.* |)\+\/\-(\d+(.\d+)?([kK])?)/)) !== null) {
+        } else if ((m = tablename.match(/^(.* |)\+\/\-(\d+(.\d+)?([kK])?)/)) !== null) {
             range.difference = GS.parseNum(m[2]);
         }
         return range;


### PR DESCRIPTION
e.g. parse 5000+, in addition to 5000+
Reorder parsing of ranges like 4000-5000 to before 5000-, as otherwise
4000-5000 will now be interpreted as 4000-
