### PR TITLE
Explain kicks only to nonguests; only on 2nd join

### DIFF
--- a/src/ext/autokick.js
+++ b/src/ext/autokick.js
@@ -15,6 +15,7 @@
         var kick, kickOrNotify, self = this;
         this.myProRating = null;
         this.kickedOpps = [];
+        this.explainedOpps = [];
 
         GS.alsoDo(FS.ZoneClassicHelper, 'onPlayerJoinTable', null, function (table, join) {
             if (this.isLocalOwner(table)) {
@@ -94,16 +95,26 @@
                 playerAddress: joiner.get('playerAddress')
             });
 
-            // Explain kick
-            console.info('kicking', self.kickedOpps, joiner);
             var oppId = joiner.get('playerAddress').slice(30, 54);
+            GS.debug(GS.get_option('explain_kicks'));
+            GS.debug(_.contains(self.kickedOpps, oppId));
+            GS.debug(!_.contains(self.explainedOpps, oppId));
+            GS.debug(joiner.get('playerName').toLowerCase().indexOf('guest') !== 0);
+            GS.debug(whyKick !== null);
+            GS.debug(whyKick);
+           
+            // Explain kick if a non-guest tries to join twice
             if (GS.get_option('explain_kicks')
-                    && !_.contains(self.kickedOpps, oppId)
+                    && _.contains(self.kickedOpps, oppId)
+                    && !_.contains(self.explainedOpps, oppId)
+                    && (joiner.get('playerName').toLowerCase().indexOf('guest') !== 0)
                     && whyKick !== null) {
                 var text = joiner.get('playerName') + ', ' + whyKick;
                 mtgRoom.conn.chat({text: text});
-                self.kickedOpps.push(oppId);
+                self.explainedOpps.push(oppId);
             }
+
+            self.kickedOpps.push(oppId);
         };
     };
 


### PR DESCRIPTION
Addresses kick explanation spam: #188

I'm not personally convinced that explaining kicks in public chat is a good idea at all... it's so annoying that I myself turned the feature off! But it's either that, drop the Isotropish level autokick, or people just get kicked without figuring out why.

Explaining only to non-guests and only on their 2nd join attempt seemed like a good compromise to me and to yed. Note that they shouldn't get any explanation on their initial or 3rd+ attempt.
