### PR TITLE
JSLint with Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,34 +1,96 @@
-module.exports = function(grunt) {
-  grunt.initConfig({
-    pkg: grunt.file.readJSON('package.json'),
+module.exports = function (grunt) {
+    'use strict';
 
-    jst: {
-      compile: {
-        options: {
-          processName: function (filepath) {
-            return filepath.slice('src/templates/'.length, -'.html'.length);
-          }
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+
+        jslint: {
+            all: {
+                src: [
+                    'Gruntfile.js',
+                    'src/ext/*.js',
+                    'src/ext/init.js.erb'
+                ],
+                exclude: [
+                    'src/ext/templates.js',
+                    'src/ext/kingdom_generator.js'
+                ],
+                directives: {
+                    ass: true,
+                    browser: true,
+                    devel: true,
+                    es5: true,
+                    forin: true,
+                    indent: 4,
+                    maxlen: 116,
+                    node: true,
+                    nomen: true,
+                    regexp: true,
+                    stupid: true, // tolerate method name ending in -Sync
+                    todo: true,
+                    unparam: true,
+                    vars: true,
+                    white: true,
+                    globals: [
+                        '$',
+                        '_',
+                        'Audio',
+                        'CampaignBattleScreen',
+                        'DEFAULT_RATING',
+                        'Dom',
+                        'DominionClient',
+                        'FS',
+                        'FormData',
+                        'GS',
+                        'Goko',
+                        'Notification',
+                        'VhonTools',
+                        'WebSocket',
+                        'angular',
+                        'mtgRoom'
+                    ]
+                }
+            }
         },
-        files: {
-          'src/ext/templates.js': 'src/templates/**/*.html'
+
+        jst: {
+            compile: {
+                options: {
+                    processName: function (filepath) {
+                        return filepath.slice('src/templates/'.length, -'.html'.length);
+                    }
+                },
+                files: {
+                    'src/ext/templates.js': 'src/templates/**/*.html'
+                }
+            }
+        },
+
+        wrap: {
+            templates: {
+                src: 'src/ext/templates.js',
+                dest: 'src/ext/templates.js',
+                options: {
+                    wrapper: ['(function () {', '}());']
+                }
+            }
+        },
+
+        watch: {
+            jslint: {
+                files: ['Gruntfile.js', 'src/ext/*.js', 'src/ext/init.js.erb'],
+                tasks: ['jslint']
+            }
         }
-      }
-    },
 
-    wrap: {
-      templates: {
-        src: 'src/ext/templates.js',
-        dest: 'src/ext/templates.js',
-        options: {
-          wrapper: ['(function () {', '}());']
-        }
-      }
-    }
+    });
 
-  });
+    grunt.loadNpmTasks('grunt-contrib-jscs');
+    grunt.loadNpmTasks('grunt-contrib-jst');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-jslint');
+    grunt.loadNpmTasks('grunt-wrap');
 
-  grunt.loadNpmTasks('grunt-contrib-jst');
-  grunt.loadNpmTasks('grunt-wrap');
-
-  grunt.registerTask('templates', ['jst', 'wrap']);
+    grunt.registerTask('lint', ['jscs:all', 'jslint:all']);
+    grunt.registerTask('templates', ['jst:compile', 'wrap:templates']);
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "devDependencies": {
     "grunt": "^0.4.4",
     "grunt-contrib-jst": "^0.6.0",
-    "grunt-wrap": "^0.3.0"
+    "grunt-jslint": "^1.1.8",
+    "grunt-wrap": "^0.3.0",
+    "grunt-contrib-watch": "^0.6.1"
   }
 }

--- a/src/ext/alwaysStack.js
+++ b/src/ext/alwaysStack.js
@@ -1,12 +1,9 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global $, _, GS, FS */
-
 (function () {
     "use strict";
 
     console.log('Loading Always Stack');
 
-    var mod = GS.modules.alwaysStack = new GS.Module('Always Stack');
+    var mod = GS.modules.alwaysStack= new GS.Module('Always Stack');
     mod.dependencies = ['GS', 'FS.Cards.CardStackPanel'];
     mod.load = function () {
         GS.alsoDo(FS.Cards.CardStackPanel, 'addView', null, function (view, index) {

--- a/src/ext/autokick.js
+++ b/src/ext/autokick.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true */
-/*global $, _, Audio, GS, FS, mtgRoom */
-
 (function () {
     "use strict";
 
@@ -12,7 +9,7 @@
         'mtgRoom.conn'
     ];
     mod.load = function () {
-        var kick, kickOrNotify, self = this;
+        var kick, self = this;
         this.myProRating = null;
         this.kickedOpps = [];
         this.explainedOpps = [];
@@ -43,7 +40,7 @@
                 var isoCrit = new RangeKickCriterion('isotropish.com rating level',
                                     GS.parseIsoRange(tableName), myIso, oppIso);
                 isoCrit.apply = GS.get_option('autokick_by_level')
-                                && typeof oppIso !== 'undefined'
+                                && oppIso !== undefined
                                 && oppIso !== null;
 
                 // Goko Pro kick criteria
@@ -63,7 +60,7 @@
                 // or when the user adds a bot to his own game
                 var room = mtgRoom.roomList.findByRoomId(mtgRoom.currentRoomId);
                 var doKickNotify = !opp.get('isBot')
-                        && typeof room !== 'undefined'
+                        && room !== undefined
                         && room.get('name').indexOf('Private') !== 0;
 
                 // Either notify the user or kick the joiner and optionally
@@ -102,7 +99,7 @@
             GS.debug(joiner.get('playerName').toLowerCase().indexOf('guest') !== 0);
             GS.debug(whyKick !== null);
             GS.debug(whyKick);
-           
+
             // Explain kick if a non-guest tries to join twice
             if (GS.get_option('explain_kicks')
                     && _.contains(self.kickedOpps, oppId)

--- a/src/ext/automatch.js
+++ b/src/ext/automatch.js
@@ -1,6 +1,5 @@
-/*jslint browser: true, devel: true, indent: 4, maxlen: 90, es5: true, vars:true, nomen:true */
-/*global $, _, WebSocket, Audio, FS, GS, mtgRoom */
-
+// unused var declarations commented out to appease jslint; unsure about just
+// removing them in case they were useful for debugging stuff
 (function () {
     "use strict";
 
@@ -8,14 +7,17 @@
     mod.dependencies = ['FS.EventDispatcher'];
     mod.load = function () {
         var loadAutomatchModule = function () {
-            var initAutomatch, automatchInitStarted, addAutomatchButton,
+            var initAutomatch,
                 fetchOwnRatings, updateAMButton, createTable,
                 fetchOwnSets, handleDisconnect,
                 connectToAutomatchServer, confirmReceipt, confirmSeek, offerMatch,
-                rescindOffer, announceGame, unannounceGame, joinAutomatchGame,
-                createAutomatchGame, enableButtonWhenAutomatchReady, showChat,
-                handleLostAutomatchConnection, enableAutoAccept, disableAutoAccept,
-                gameReady, attemptAutomatchInit, testPop, sendAutoAutomatchSeekRequest;
+                rescindOffer, announceGame, unannounceGame,
+                createAutomatchGame, showChat,
+                enableAutoAccept, disableAutoAccept,
+                gameReady, sendAutoAutomatchSeekRequest;
+            // var addAutomatchButton, joinAutomatchGame, enableButtonWhenAutomatchReady,
+            //     testPop, handleLostAutomatchConnection, attemptAutomatchInit,
+            //     automatchInitStarted;
 
             // Configuration
             GS.AM = GS.AM || {};
@@ -31,7 +33,7 @@
             }
 
             // Initial state
-            automatchInitStarted = false;
+            // automatchInitStarted = false;
             GS.AM.tableSettings = null;
             GS.AM.wsFailCount = 0;
             GS.AM.noreconnect = false;
@@ -156,7 +158,7 @@
 
                     // Disable auto-reconnect and disconnect from automatch server
                     GS.AM.noreconnect = true;
-                    if (typeof GS.AM.ws !== 'undefined'
+                    if (GS.AM.ws !== undefined
                             && GS.AM.ws !== null
                             && GS.AM.ws.readyState === 1) {
                         GS.AM.ws.close();
@@ -174,7 +176,7 @@
 
                         // Enable auto-reconnect and connect to automatch server
                         GS.AM.noreconnect = false;
-                        if (typeof GS.AM.ws === 'undefined'
+                        if (GS.AM.ws === undefined
                                 || GS.AM.ws === null
                                 || GS.AM.ws.readyState !== 1) {
                             connectToAutomatchServer();
@@ -194,7 +196,7 @@
 
                         // Disable auto-reconnect and disconnect from automatch server
                         GS.AM.noreconnect = true;
-                        if (typeof GS.AM.ws !== 'undefined'
+                        if (GS.AM.ws !== undefined
                                 && GS.AM.ws !== null
                                 && GS.AM.ws.readyState === 1) {
                             GS.AM.ws.close();
@@ -211,7 +213,7 @@
                     // TODO: look up guest ratings correctly
                     GS.AM.player.rating.goko_casual_rating = 1000;
                     GS.AM.player.rating.goko_pro_rating = 1000;
-                    if (typeof frCallback !== undefined) {
+                    if (frCallback !== undefined) {
                         frCallback();
                     }
 
@@ -226,10 +228,10 @@
                         ratingSystemId: GS.AM.CASUAL_SYS_ID
                     }, function (resp) {
                         GS.AM.player.rating.goko_casual_rating = resp.data.rating;
-                        if (typeof resp.data.rating === 'undefined') {
+                        if (resp.data.rating === undefined) {
                             GS.AM.player.rating.goko_casual_rating = 1000;
                         }
-                        if (typeof frCallback !== undefined) {
+                        if (frCallback !== undefined) {
                             frCallback();
                         }
                     });
@@ -240,11 +242,11 @@
                         ratingSystemId: GS.AM.PRO_SYS_ID
                     }, function (resp) {
                         GS.AM.player.rating.goko_pro_rating = resp.data.rating;
-                        if (typeof resp.data.rating === 'undefined') {
+                        if (resp.data.rating === undefined) {
                             GS.AM.player.rating.goko_pro_rating = 1000;
                         }
                         GS.AM.player.ratingsDirty = false;
-                        if (typeof frCallback !== undefined) {
+                        if (frCallback !== undefined) {
                             frCallback();
                         }
                     });
@@ -256,7 +258,7 @@
                 if (GS.AM.player.kind === "guest") {
                     // Guests only have Base. No need to check.
                     GS.AM.player.sets_owned = ['Base'];
-                    if (typeof fsCallback !== undefined) {
+                    if (fsCallback !== undefined) {
                         fsCallback();
                     }
                 } else {
@@ -299,7 +301,7 @@
                                     }
                                 });
                                 GS.AM.player.sets_owned = setsOwned;
-                                if (typeof fsCallback !== undefined) {
+                                if (fsCallback !== undefined) {
                                     fsCallback();
                                 }
                             });
@@ -327,7 +329,7 @@
 
                     // Ping AM server every 25 sec. Timeout if no messages (including
                     // pingbacks) received for 180 sec.
-                    if (typeof GS.AM.pingLoop !== 'undefined') {
+                    if (GS.AM.pingLoop !== undefined) {
                         clearInterval(GS.AM.pingLoop);
                     }
                     GS.AM.pingLoop = setInterval(function () {
@@ -337,7 +339,7 @@
                             clearInterval(GS.AM.pingLoop);
                             try {
                                 GS.AM.ws.close();
-                            } catch (e) {}
+                            } catch (ignore) {}
                         } else {
                             GS.debug('Sending ping');
                             GS.AM.ping();
@@ -410,7 +412,8 @@
             };
 
             updateAMButton = function () {
-                var connected, gotPlayerInfo, ready, buttonText, buttonColor;
+                var ready, buttonText, buttonColor;
+                // var connected, gotPlayerInfo;
 
                 if (!GS.AM.player.hasOwnProperty('sets_owned')
                         || !GS.AM.player.rating.hasOwnProperty('goko_casual_rating')
@@ -418,7 +421,7 @@
                     ready = false;
                     buttonText = 'Automatch: Initializing';
                     buttonColor = 'LightGray';
-                } else if (typeof GS.AM.ws === 'undefined') {
+                } else if (GS.AM.ws === undefined) {
                     ready = false;
                     buttonText = 'Automatch: Connecting';
                     buttonColor = 'LightGray';
@@ -461,7 +464,7 @@
                 updateAMButton();
 
                 // Stop trying to ping
-                if (typeof GS.AM.pingLoop !== 'undefined') {
+                if (GS.AM.pingLoop !== undefined) {
                     clearInterval(GS.AM.pingLoop);
                 }
 
@@ -484,7 +487,7 @@
             confirmReceipt = function (msg) {
                 GS.debug('Receipt of message confirmed: ' + msg.msgid);
                 var crCallback = GS.AM.ws.callbacks[msg.msgid];
-                if (typeof crCallback !== 'undefined' && crCallback !== null) {
+                if (crCallback !== undefined && crCallback !== null) {
                     //GS.debug(crCallback);
                     crCallback();
                 }
@@ -511,7 +514,7 @@
                 GS.AM.tableSettings = null;
                 // TODO: handle this in a more UI-consistent way
                 GS.AM.showOfferPop(false);
-    
+
                 var chatText = $('#amChatArea').val();
                 GS.notifyUser('Automatch offer was rescinded:\n' + msg.reason
                         + (chatText ? '  ' + chatText : ''));
@@ -557,11 +560,11 @@
                 if (GS.AM.state.game.hostname !== GS.AM.player.pname) {
                     var joinGame = function () {
                         GS.AM.gokoconn.unbind(GS.AM.ENTER_LOBBY, joinGame);
-                        var table, seatindex, joinOpts;
-                        table = GS.AM.mtgRoom.roomList
-                            .where({roomId: GS.AM.mtgRoom.currentRoomId})[0]
-                            .get('tableList')
-                            .where({number: GS.AM.state.game.tableindex})[0];
+                        var seatindex, joinOpts;
+                        // var table = GS.AM.mtgRoom.roomList
+                        //     .where({roomId: GS.AM.mtgRoom.currentRoomId})[0]
+                        //     .get('tableList')
+                        //     .where({number: GS.AM.state.game.tableindex})[0];
                         seatindex = GS.AM.state.game.seeks.map(function (seek) {
                             return seek.player.pname;
                         }).filter(function (pname) {
@@ -708,15 +711,15 @@
 
             var rangeToRequirement = function (range, rSystem) {
                 var out;
-                if (typeof range.difference !== 'undefined') {
+                if (range.difference !== undefined) {
                     out = {rclass: 'RelativeRating', props: {}};
                     out.propsjpts_lower = range.difference;
                     out.props.pts_higher = range.difference;
                 } else {
                     out = {rclass: 'AbsoluteRating', props: {}};
-                    out.props.min_pts = typeof range.min !== 'undefined'
+                    out.props.min_pts = range.min !== undefined
                                              ? range.min : null;
-                    out.props.max_pts = typeof range.max !== 'undefined'
+                    out.props.max_pts = range.max !== undefined
                                              ? range.max : null;
                 }
                 out.props.rating_system = rSystem;
@@ -743,8 +746,8 @@
                 }
 
                 // Do not automatch if looking for a particular opponent
-                var m;
-                if ((m = tName.toLowerCase().match(/for\s*\S*/)) !== null) {
+                var m = tName.toLowerCase().match(/for\s*\S*/);
+                if (m !== null) {
                     GS.debug('Table is for a specific opp; no automatch');
                 } else {
                     var np, rs, vp, rGoko, rIso;
@@ -833,7 +836,7 @@
 
             disableAutoAccept = function () {
                 var reqView = GS.AM.mtgRoom.views.ClassicRoomsPermit;
-                if (typeof reqView.showByRequest_orig !== 'undefined') {
+                if (reqView.showByRequest_orig !== undefined) {
                     reqView.showByRequest = reqView.showByRequest_orig;
                 }
             };
@@ -842,7 +845,8 @@
                 var reqView = GS.AM.mtgRoom.views.ClassicRoomsPermit;
                 reqView.showByRequest_orig = reqView.showByRequest;
                 reqView.showByRequest = function (request) {
-                    var joinerName, opts, isAutomatchOpp;
+                    var joinerName, isAutomatchOpp;
+                    // var opts;
 
                     joinerName = GS.AM.mtgRoom.playerList
                                 .findByAddress(request.data.playerAddress)
@@ -870,7 +874,8 @@
                     GS.AM.zch.leaveTable(GS.AM.zch.currentTable);
                 }
 
-                var seatsState, tKingdom, tSettings, tOpts;
+                var seatsState, tSettings, tOpts;
+                // var tKingdom;
                 seatsState = [1, 2, 3, 4, 5, 6].map(function (i) {
                     return (i <= opps.length + 1);
                 });
@@ -929,12 +934,12 @@
                     var mtgRoom = window.mtgRoom;
                     var conn = mtgRoom.conn;
                     var zch = mtgRoom.helpers.ZoneClassicHelper;
-                    if (typeof conn !== 'undefined' && typeof zch !== 'undefined') {
+                    if (conn !== undefined && zch !== undefined) {
                         alreadyLoaded = true;
                         console.log('Not already loaded Automatch');
                         loadAutomatchModule();
                     }
-                } catch (e) {}
+                } catch (ignore) {}
             }
         });
     };

--- a/src/ext/automatchGamePop.js
+++ b/src/ext/automatchGamePop.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, maxlen: 90, es5: true */
-/*global $, GS */
-
 (function () {
     "use strict";
 
@@ -42,7 +39,7 @@
 
         // Update and show/hide the dialog
         GS.AM.showGamePop = function (visible) {
-            if (typeof visible === "undefined") {
+            if (visible === undefined) {
                 visible = true;
             }
 

--- a/src/ext/automatchOfferPop.js
+++ b/src/ext/automatchOfferPop.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, maxlen: 90, es5: true, vars:true */
-/*global $, GS */
-
 (function () {
     "use strict";
 
@@ -82,7 +79,7 @@
 
         // Update and show/hide the dialog
         GS.AM.showOfferPop = function (visible) {
-            if (typeof visible === "undefined") {
+            if (visible === undefined) {
                 visible = true;
             }
 

--- a/src/ext/automatchSeekPop.js
+++ b/src/ext/automatchSeekPop.js
@@ -1,10 +1,7 @@
-/*jslint browser: true, devel: true, indent: 4, maxlen: 90, es5: true */
-/*global $, angular, GS */
-
 (function () {
     "use strict";
 
-    var mod = GS.modules.automatchSeekPop = new GS.Module('Automatch Seek Popup');
+    var mod = GS.modules.automatchSeekPop=  new GS.Module('Automatch Seek Popup');
     mod.dependencies = ['$'];
     mod.load = function () {
         GS.AM = GS.AM || {};
@@ -278,7 +275,7 @@
             $('#seekhide').prop('disabled', false);
             $('#seekstatus').html(seeking ? 'Looking for a match...' : '');
 
-            if (typeof visible === "undefined") {
+            if (visible === undefined) {
                 visible = true;
             }
 

--- a/src/ext/autozap.js
+++ b/src/ext/autozap.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true */
-/*global $, _, GS, VhonTools, CampaignBattleScreen */
-
 (function () {
     "use strict";
 
@@ -9,7 +6,7 @@
         'CampaignBattleScreen.prototype.show_campaign_battle'
     ];
     mod.load = function () {
-        var zapitup, i, j;
+        var zapitup, i;
         zapitup = function () {
             VhonTools.zaps.total = 80;
             var j = 0;
@@ -28,23 +25,3 @@
         }
     };
 }());
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/ext/avatarUpload.js
+++ b/src/ext/avatarUpload.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true */
-/*global $, _, GS, FS, mtgRoom, FormData */
-
 (function () {
     "use strict";
 
@@ -40,7 +37,7 @@
         $('#auInput').change(function () {
             var file = this.files[0];
             var type = file.type;
-        
+
             if (type === 'image/jpeg' || type === 'image/png' || type === 'image/gif') {
                 $('#auButton').prop('disabled', false);
                 $('#auInfo').html('Ready to submit.');
@@ -48,7 +45,7 @@
                 $('#auButton').prop('disabled', true);
                 $('#auInfo').html('Invalid file type.  Please select an image file.');
             }
-        
+
             if (file.size / 1000 > 1000) {
                 $('#auInfo').html('File is too large: 1 MB max');
                 $('#auButton').prop('disabled', true);

--- a/src/ext/avatars.js
+++ b/src/ext/avatars.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true */
-/*global $, _, GS, Goko, FS, mtgRoom */
-
 (function () {
     "use strict";
 
@@ -33,7 +30,7 @@
             //       here.  The Goko framework will resize as necessary.
             var img = new Image();
             img.onerror = function () {
-                // Defer to goko if GokoSalvager has gone offline or does not 
+                // Defer to goko if GokoSalvager has gone offline or does not
                 // have a custom avatar.
                 gokoAvatarLoader(userdata, callback);
             };
@@ -65,11 +62,12 @@
         // 1. Use the GS websocket to ask whether a custom avatar exists.
         // 2a. Look up a custom avatar from GS via https
         // 2b. Look up a vanilla avatar using the regular goko method
-        // 
+        //
         // Goko should also provide any large (size >= 3) versions of the
         // avatars, even if a custom one is available.
         //
-        var SMALL = 1, MEDIUM = 2;
+        // var SMALL = 1
+        var MEDIUM = 2;
 
         Goko.Player.AvatarLoader = function (userdata, callback) {
             // If displaying the launch (title) screen before the hasAvatar[]
@@ -82,7 +80,7 @@
             //
             if (userdata.which > MEDIUM) {
                 gokoAvatarLoader(userdata, callback);
-            } else if (typeof GS.hasAvatar === 'undefined') {
+            } else if (GS.hasAvatar === undefined) {
                 if (mtgRoom.currentRoomId === null && userdata.which <= MEDIUM) {
                     gsAvatarLoader(userdata, callback);
                 } else {
@@ -93,7 +91,7 @@
                     }
                     retroboxAvatarLoader(userdata, callback);
                 }
-            } else if (typeof GS.hasAvatar[userdata.player.id] !== 'undefined') {
+            } else if (GS.hasAvatar[userdata.player.id] !== undefined) {
                 if (GS.hasAvatar[userdata.player.id]) {
                     gsAvatarLoader(userdata, callback);
                 } else {
@@ -111,12 +109,14 @@
         // Prevent Goko's preloader from building a cache of vanilla avatars.
         // Note that the cache will still be populated later and used, but it
         // will be populated using our avatar loading code rather than Goko's.
-        Goko.Player.preloader = function (ids, which) {};
+        Goko.Player.preloader = function (ids, which) {
+          GS.debug('Goko.Player.preloader()');
+        };
 
         // Also clear anything that got into the cache befor this module loaded
         try {
             Goko.ObjectCache.getInstance().player = {};
-        } catch (e) {
+        } catch (ignore) {
             // Player cache does not yet exist --> no need to clear it
         }
     };

--- a/src/ext/blacklist.js
+++ b/src/ext/blacklist.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global $, _, GS, FS */
-
 (function() {
     "use strict";
 
@@ -17,7 +14,7 @@
 
             // Hide chat messages from censored players
             var blist = GS.getCombinedBlacklist();
-            if (typeof blist[player] === 'undefined' || !blist[player].censor) {
+            if (blist[player] === undefined || !blist[player].censor) {
                 this.old_onRoomChat(resp);
             }
         };
@@ -34,7 +31,7 @@
                     GS.cachedCommonBlacklist = resp.common_blacklist;
                     GS.commonBlacklistRetreived = true;
                     console.log('Retrieved and cached common blacklist');
-                    if (typeof callback !== 'undefined') {
+                    if (callback !== undefined) {
                         callback();
                     }
                 }
@@ -69,9 +66,9 @@
         FS.ClassicTableView.prototype.old_modifyDOM = FS.ClassicTableView.prototype.modifyDOM;
         FS.ClassicTableView.prototype.modifyDOM = function () {
             FS.ClassicTableView.prototype.old_modifyDOM.call(this);
-    
+
             var players, name, blacklisted, localPlayerJoined;
-    
+
             if (this.model && this.model.getJoinedPlayers) {
 
                 players = this.model.getJoinedPlayers();
@@ -81,7 +78,7 @@
 
                     // Determine whether a blacklisted player is at the table
                     var blist = GS.get_option('blacklist2');
-                    if (typeof blist[name] !== 'undefined' && !blist[name].noplay
+                    if (blist[name] !== undefined && !blist[name].noplay
                             && this.model && this.model.view && this.model.view.$el) {
                         blacklisted = true;
                     }
@@ -91,7 +88,7 @@
                         localPlayerJoined = true;
                     }
                 }, this);
-    
+
                 if (blacklisted && !localPlayerJoined) {
                     // Hide games with blacklisted players unless we're in them too
                     this.model.view.$el.hide();

--- a/src/ext/blacklistSync.js
+++ b/src/ext/blacklistSync.js
@@ -1,6 +1,3 @@
-/*jslint browser:true, devel:true, es5:true, nomen:true, forin:true, vars:true */
-/*globals $, _, angular, GS, */
-
 (function () {
     "use strict";
     console.log('Loading Settings Dialog');
@@ -8,7 +5,7 @@
     GS.modules.blacklistSync.dependencies = [
         '$',
         'angular',
-        'GS.WS',
+        'GS.WS'
     ];
     GS.modules.blacklistSync.load = function () {
 
@@ -94,7 +91,7 @@
                 }
             });
         };
-    
+
         GS.submitBlacklist = function () {
             var blist = GS.get_option('blacklist2');
 
@@ -114,7 +111,7 @@
                           + 'Cannot submit blacklist.');
             }
         };
-    
+
         // angularJS Controller for blacklist reconciliation UI
         window.blReconcileController = function ($scope) {
             $scope.local = null;

--- a/src/ext/chatbox.js
+++ b/src/ext/chatbox.js
@@ -1,12 +1,7 @@
-/*jslint vars:true, nomen:true, forin:true, regexp:true, browser:true, devel:true */
-
-/*globals _, $, GS, mtgRoom, Dom, Audio */
-
 // TODO: Immediately send Turn 2 messages when opponents have all joined the game.
 
 (function () {
     "use strict";
-
 
     GS.modules.chatbox = new GS.Module('Chat Box');
     GS.modules.chatbox.dependencies = [
@@ -20,7 +15,8 @@
         var pname2pclass;
         var gameClient;
 
-        var chatHistory = [];
+        // commented to appease jslint
+        // var chatHistory = [];
 
         // Add the chat box widget to the sidebar. The sidebar module is
         // responsible for whether to display it or not.
@@ -61,12 +57,16 @@
         // Fake version has methods for game window destructor to call.
         var createRealGokoChatManager = Dom.DominionWindow.prototype._createChatManager;
         var createFakeGokoChatManager = function () {
-		    var dominionWindow = this;
 		    var chatManager = {
-                destroy: function () {},
-                addChat: function () {
+                destroy: function () {
+                  GS.debug('chatManager.destroy()');
                 },
-                setVisible: function () {}
+                addChat: function () {
+                  GS.debug('chatManager.addChat()');
+                },
+                setVisible: function () {
+                  GS.debug('chatManager.setVisible()');
+                }
             };
 		    this.chatManager = chatManager;
 	    };
@@ -132,7 +132,7 @@
                 $('#chatline').empty();
 
                 // Stop listening to the old game client
-                if (typeof gameClient !== 'undefined' && gameClient !== null) {
+                if (gameClient !== undefined && gameClient !== null) {
                     gameClient.unbind('incomingMessage:gameSetup', onGameSetup);
                     mtgRoom.unbind('MeetingRoom:Game:ClientExit', onOppExit);
                 }

--- a/src/ext/connection.js
+++ b/src/ext/connection.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, maxlen: 90, es5: true, vars:true, white:true, nomen:true */
-/*global $, _, WebSocket, GS, mtgRoom */
-
 // Create a single WebSocket connection to gokosalvager.com
 //
 // I plan to use this connection for all client-server communication, including:
@@ -23,14 +20,15 @@
     ];
     mod.load = function () {
 
-        var startPingLoop, handleDisconnect, updateWSIcon, confirmReceipt;
+        var startPingLoop, handleDisconnect, updateWSIcon;
+        // var confirmReceipt;
 
         console.log('Loading WS Connection module');
 
         // Connection variables
         GS.WS = {};
         GS.WS.domain = 'gokosalvager.com';
-        GS.WS.port = 8889;  // TODO: Switch from port 8889 back to 443 after 
+        GS.WS.port = 8889;  // TODO: Switch from port 8889 back to 443 after
                             //       server transition
         GS.WS.url = "wss://" + GS.WS.domain + ":" + GS.WS.port + "/gs/websocket";
         GS.WS.noreconnect = false;
@@ -61,7 +59,7 @@
             GS.WS.conn.onmessage = function (evt) {
                 var d = JSON.parse(evt.data);
                 var m = d.message;
-                
+
                 GS.WS.lastpingTime = new Date();
 
                 switch (d.msgtype) {
@@ -80,7 +78,7 @@
                     // Evaluate the callback the client registered, with the
                     // server's response as its argument.
                     var callback = GS.WS.callbacks[m.queryid];
-                    if (typeof callback !== 'undefined') {
+                    if (callback !== undefined) {
                         if (callback !== null) {
                             callback(m);
                         }
@@ -104,7 +102,7 @@
         };
 
         GS.WS.isConnReady = function () {
-            return typeof GS.WS.conn !== 'undefined'
+            return GS.WS.conn !== undefined
                 && GS.WS.conn.readyState === 1
                 && GS.WS.clientInfoReceived;
         };
@@ -122,7 +120,7 @@
         // Convenience wrapper for websocket send() method.  Globally accessible.
         var msgcount = 0;
         GS.WS.sendMessage = function (msgtype, msg, smCallback) {
-            
+
             var msgid, msgJSON;
 
             msgcount += 1;
@@ -133,7 +131,7 @@
                 msgid: msgid
             });
 
-            if (typeof smCallback !== 'undefined' && smCallback !== null) {
+            if (smCallback !== undefined && smCallback !== null) {
                 GS.WS.callbacks[msgid] = smCallback;
             }
 
@@ -180,7 +178,7 @@
             updateWSIcon();
 
             // Stop the ping cycle
-            if (typeof GS.WS.pingLoop !== 'undefined') {
+            if (GS.WS.pingLoop !== undefined) {
                 clearInterval(GS.WS.pingLoop);
             }
 

--- a/src/ext/decktracker.js
+++ b/src/ext/decktracker.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, es5: true, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global _, $, GS, Audio, Dom, FS */
-
 (function () {
     "use strict";
 
@@ -15,14 +12,14 @@
 
         GS.cardCounts = {};
         GS.vptokens = {};
-    
+
         // "Listen" to live log messages
         GS.alsoDo(Dom.LogManager, 'addLog', function (opt) {
             if (opt.text) {
                 parseLogLine(opt.text);
             }
         });
-    
+
         getHumanCardName = function (codedCardName) {
             // Strip the numbers
             codedCardName = codedCardName.replace(/\.\d+$/, '');
@@ -34,35 +31,35 @@
             GS.debug(c);
             return c.name[0];
         };
-    
+
         // "Listen" to card moves that may be Masquerade passes
         // (Masquerade passes do not appear in the live log)
         GS.alsoDo(Dom.DominionWindow, '_moveCards', function (options, callback) {
-            var i;
+            var i, move, srcArea, dstArea, passedCard;
             for (i = 0; i < options.moves.length; i += 1) {
-                var move = options.moves[i];
-                var srcArea = move.source.area;
-                var dstArea = move.destination.area;
+                move = options.moves[i];
+                srcArea = move.source.area;
+                dstArea = move.destination.area;
                 if (srcArea.name === 'reveal' && dstArea.name === 'hand'
                         && srcArea.playerIndex !== dstArea.playerIndex) {
-    
+
                     // This is a name like 'grandMarket.3'; translate it
-                    var passedCard = move.sourceCard;
+                    passedCard = move.sourceCard;
                     GS.debug('Passed: ' + passedCard);
                     passedCard = getHumanCardName(passedCard);
-    
+
                     GS.debug('Translated: ' + passedCard);
                     GS.debug(pnames);
                     GS.debug(srcArea.playerIndex);
                     GS.debug(dstArea.playerIndex);
-    
+
                     // Decrement the passer's count, increment the recipient's
                     alterCardCount(pnames[srcArea.playerIndex], passedCard, -1);
                     alterCardCount(pnames[dstArea.playerIndex], passedCard, 1);
                 }
             }
         });
-    
+
         var startPatt = new RegExp(/^-+ Game Setup -+$/);
         var turnPatt = new RegExp(/^-+ (.*): turn \d+( \[possessed\])? -+$/);
         var returnPatt = new RegExp(/(.*) - returns (.*) to the Supply/);
@@ -74,39 +71,39 @@
         var madmanPatt = new RegExp(/(.*) - plays Madman/);
         // TODO: Are Monument or Goons bugged too?
         var bishopPatt = new RegExp(/(.*) - plays Bishop/);
-    
+
         var turnPlayerName, possessed;
         parseLogLine = function (line) {
-            var m, actorName, card;
+            var m, actorName;
             if (line.match(startPatt)) {
                 GS.cardCounts = {};
                 GS.vptokens = {};
                 pnames = [];
-    
+
             } else if ((m = line.match(startingCardsPatt)) !== null) {
-    
+
                 // Initialize players' card/vptoken counts
                 actorName = m[1];
                 GS.cardCounts[actorName] = {};
                 GS.vptokens[actorName] = 0;
                 pnames.push(actorName);
-    
+
                 // Add starting cards
                 m[2].split(', ').map(function (card) {
                     alterCardCount(actorName, card, 1);
                 });
-    
+
             } else if ((m = line.match(turnPatt)) !== null) {
                 // Keep track of whose turn it is
                 turnPlayerName = m[1];
                 possessed = m[2] === ' [possessed]';
-    
+
             } else if ((m = line.match(gainPatt)) !== null) {
                 alterCardCount(m[1], m[2], 1);
-    
+
             } else if ((m = line.match(returnPatt)) !== null) {
                 alterCardCount(m[1], m[2], -1);
-    
+
             } else if ((m = line.match(trashPatt)) !== null) {
                 actorName = m[1];
                 m[2].split(', ').map(function (card) {
@@ -121,22 +118,22 @@
                         alterCardCount(actorName, card, -1);
                     }
                 });
-    
+
             } else if ((m = line.match(bishopPatt)) !== null) {
                 // Bishop's +1 VP doesn't show up in the live log
                 GS.vptokens[m[1]] += 1;
-    
+
             } else if ((m = line.match(vptokenPatt)) !== null) {
                 GS.vptokens[m[1]] += parseInt(m[2], 10);
-    
+
             } else if ((m = line.match(spoilsPatt)) !== null) {
                 alterCardCount(m[1], 'Spoils', -1);
-    
+
             } else if ((m = line.match(madmanPatt)) !== null) {
                 alterCardCount(m[1], 'Madman', -1);
             }
         };
-    
+
         alterCardCount = function (pname, card, n) {
             if (card === 'JackOfAllTrades') {
                 card = 'Jack of All Trades';

--- a/src/ext/eventLogger.js
+++ b/src/ext/eventLogger.js
@@ -1,12 +1,9 @@
-/*jslint browser:true, devel:true, nomen:true, forin:true, vars:true, regexp:true, white:true */
-/*globals $, _, angular, FS, DominionClient, GS */
-
 (function () {
     "use strict";
 
     GS.modules.eventLogger = new GS.Module('Event Logger');
     GS.modules.eventLogger.dependencies = [
-        'DominionClient', 
+        'DominionClient',
         'FS.Connection',
         'FS.GameInstance'
     ];
@@ -17,7 +14,8 @@
             Connection: [],
             GameInstance: []
         };
-        var eh = window.eventHistory;
+
+        // var eh = window.eventHistory;
 
         GS.alsoDo(FS.MeetingRoom, 'trigger', function (msg) {
             //eh.MeetingRoom.push(arguments);
@@ -31,7 +29,7 @@
             console.log('Connection: ' + msg);
             console.log(Array.prototype.slice.call(arguments,1));
         });
-        
+
         //GS.alsoDo(FS.GameInstance, 'trigger', function (msg) {
         //    eh.MeetingRoom.push(arguments);
         //    console.log('GameInstance: ' + msg);

--- a/src/ext/init.js.erb
+++ b/src/ext/init.js.erb
@@ -1,6 +1,3 @@
-/*jslint browser:true, devel:true, vars:true, forin:true, nomen:true */
-/*globals $, _ */
-
 (function () {
     "use strict";
 
@@ -141,7 +138,7 @@
                         return true;
                     }
                 }
-                return typeof dep === 'undefined' || dep === null;
+                return dep === undefined || dep === null;
             });
         };
 

--- a/src/ext/kingdom_generator.js
+++ b/src/ext/kingdom_generator.js
@@ -1,7 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*globals $, _, GS, FS */
-
-
 //esoteric functions and card definitions
 var kinggen_utils = {};
 kinggen_utils = (function () {

--- a/src/ext/launchScreenLoader.js
+++ b/src/ext/launchScreenLoader.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true */
-/*global $, _, GS, FS, mtgRoom */
-
 (function () {
     "use strict";
     console.log('Loading LaunchScreenLoader');
@@ -57,13 +54,13 @@
         };
 
         // Loop until Goko finishes preparing the launch screen, then make
-        // our modifications. 
+        // our modifications.
         var intv, delay = 250, count = 0;
         var checkReadyAndModify = function () {
             var ls = FS.LaunchScreen.getInstance();
-            if (typeof ls !== 'undefined'
-                    && typeof ls.container !== 'undefined'
-                    && typeof ls.container.isReady !== 'undefined'
+            if (ls !== undefined
+                    && ls.container !== undefined
+                    && ls.container.isReady !== undefined
                     && ls.container.isReady === true) {
 
                 console.log('Launch Screen ready.');

--- a/src/ext/lobby_ratings.js
+++ b/src/ext/lobby_ratings.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global $, _, GS, FS, mtgRoom, DEFAULT_RATING */
-
 /*
  * Lobby ratings module
  *
@@ -34,7 +31,7 @@
         }
 
         // Cache all Isotropish ratings
-        var noIsoCacheWarned = false;
+        GS.noIsoCacheWarned = false;
         var queuedRequests = [];
         GS.WS.waitSendMessage('QUERY_ISO_TABLE', {}, function (resp) {
 
@@ -61,7 +58,7 @@
             // and playerName.  This will also allow the server to record the
             // id-name connection.
             //
-            if (typeof GS.isoLevelCache[playerId] !== 'undefined') {
+            if (GS.isoLevelCache[playerId] !== undefined) {
                 // Player in cache
                 updateIsoRating2(playerId, playerElement);
             } else {
@@ -69,7 +66,7 @@
                 var player = mtgRoom.playerList.findById(playerId)[0];
 
                 // Undefined if player has already left lobby --> ignore him
-                if (typeof player !== 'undefined') {
+                if (player !== undefined) {
                     var playerName = player.get('playerName');
                     var msg = {
                         playerId: playerId,
@@ -126,7 +123,9 @@
 
                     // insert iso level right after Goko Pro rating
                     opts.$el.closest('div').find('.vp-rating-pro').closest('p')
-                        .after(GS.template('popup-iso-level', { level: GS.isoLevelCache[opts.playerId] }));
+                        .after(GS.template('popup-iso-level', {
+                            level: GS.isoLevelCache[opts.playerId]
+                        }));
                 };
             }
 
@@ -153,11 +152,12 @@
             var newEl = getSortablePlayerObjectFromElement(element),
                 elements = list.children,
                 b = elements.length,
-                a = 0;
+                a = 0,
+                c, compare;
 
             while (a !== b) {
-                var c = Math.floor((a + b) / 2);
-                var compare = getSortablePlayerObjectFromElement(elements[c]);
+                c = Math.floor((a + b) / 2);
+                compare = getSortablePlayerObjectFromElement(elements[c]);
 
                 // sort first by rating, then alphabetically
                 if (compare > newEl) {
@@ -195,11 +195,11 @@
                 try {
                     var playerId = playerElement.querySelector('.player-list-item')
                                                 .getAttribute('data-playerid');
-                    var playerName = mtgRoom.playerList
-                                            .findById(playerId)[0]
-                                            .get('playerName');
+                    // var playerName = mtgRoom.playerList
+                    //                         .findById(playerId)[0]
+                    //                         .get('playerName');
 
-                    if (typeof GS.isoLevelCache === 'undefined') {
+                    if (GS.isoLevelCache === undefined) {
                         // Warn that the cache is not available
                         if (!GS.noIsoCacheWarned) {
                             console.log('ISO level cache not yet '
@@ -217,7 +217,7 @@
                         // Update player's lobby list element.
                         updateIsoRating(playerId, playerElement);
                     }
-                } catch (e) {
+                } catch (ignore) {
                     // Players sometimes disappear from the list before
                     // this code is reached.  Ignore these errors.
                 }
@@ -227,7 +227,7 @@
             var blist = GS.getCombinedBlacklist(true);
             var pname = playerElement
                 .querySelector('.fs-mtrm-player-name>strong').innerHTML;
-            if (typeof blist[pname.toLowerCase()] !== 'undefined'
+            if (blist[pname.toLowerCase()] !== undefined
                     && blist[pname.toLowerCase()].censor) {
                 $(playerElement).hide();
             } else {

--- a/src/ext/logviewer.js
+++ b/src/ext/logviewer.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, es5: true, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global _, $, Audio, GS, FS, Dom, DominionClient */
-
 (function () {
     "use strict";   // JSLint setting
 
@@ -18,7 +15,7 @@
         var pname2pclass;
 
         // Current player/phase
-        var gamePhase, logPhase, possessed, gameStarted, gameOver;
+        var gamePhase, logPhase, gameStarted, gameOver;
 
         // "Listen" to game phase changes. These always precede the log messages
         // of the new phase.
@@ -40,7 +37,8 @@
             if (opt.logUrl) {
                 // Link to gokosalvager.com prettified log instead of Goko
                 // Credit to nutki for prettifier code
-                opt.logUrl = 'http://www.gokosalvager.com/static/logprettifier.html?' + opt.logUrl.substr(40);
+                opt.logUrl = 'http://www.gokosalvager.com/static/logprettifier.html?' +
+                    opt.logUrl.substr(40);
             }
             if (opt.text) {
                 parseLogLine(opt.text);
@@ -62,7 +60,7 @@
         }).join('|'), 'g');
 
         // Append a list of formatted cards to the log
-        // Ex: ['Copper', 'Estate'] appends 
+        // Ex: ['Copper', 'Estate'] appends
         // <span class="treasure">Copper</span>, <span class="victory">Estate</span>
         logAppendCards = function (cardList) {
             var i, card, cardTitle;
@@ -100,7 +98,7 @@
         var gameOverPatt = new RegExp(/^-+ Game Over -+$/);
 
         parseLogLine = function (line) {
-            var m, pname, pclass;
+            var m, pname, pclass;//, startingCards;
 
             if (line.match(setupPatt)) {
                 $('#prettylog').empty();
@@ -121,8 +119,11 @@
                 gameStarted = true;
 
             } else if ((m = line.match(startingCardsPatt)) !== null) {
+                var startingCards;
+                GS.debug(startingCards);
+
                 pname = m[1];
-                var startingCards = m[2];
+                startingCards = m[2];
                 logAppendPlayer(pname);
                 logAppend(' starting cards: ');
                 logAppendCards(m[2].split(', '));
@@ -155,7 +156,7 @@
                     cards.push(match);
                     return '--XXX--';
                 }).split('--XXX--');
-                var i, nctext;
+                var i;
                 for (i = 0; i < nonCardText.length; i += 1) {
                     logAppend(' ' + nonCardText[i] + ' ');
                     if (i < cards.length) {

--- a/src/ext/module_loader.js
+++ b/src/ext/module_loader.js
@@ -1,6 +1,3 @@
-/*jslint browser:true, devel:true, white:true, vars:true, forin:true */
-/*globals $, angular, GS, mtgRoom */
-
 (function () {
     "use strict";
 
@@ -19,7 +16,7 @@
         'notifications',
         'lobbyRatings',
         'decktracker',
-        'tableState', 
+        'tableState',
         'autokick',
         'kingdomGenerator',
         'speedTweak',
@@ -29,7 +26,7 @@
         'automatchSeekPop',
         'automatch',
         'quickGame',
-        'sidebar',              
+        'sidebar',
         'logviewer',            // Depends on sidebar
         'vpcalculator',         // Depends on sidebar
         'vptoggle',             // Depends on sidebar
@@ -53,7 +50,7 @@
             }
         } else {
             var intvl = setInterval(function () {
-                var missing = mod.getMissingDeps();
+                missing = mod.getMissingDeps();
                 if (missing.length === 0) {
                     clearInterval(intvl);
                     console.log('Loading module ' + mod.name);

--- a/src/ext/notifications.js
+++ b/src/ext/notifications.js
@@ -1,11 +1,8 @@
-/*jslint vars:true, nomen:true, forin:true, regexp:true, browser:true, devel:true */
-/*globals _, $, GS, Notification */
-
 (function () {
     "use strict";
 
-    var chromeUnblock = 'Settings/advanced settings/Privacy/Content Settings/Notifications/Manage Exceptions/';
-    var firefoxUnblock = 'Tools/Page Info/Permissions/Show Notifications';
+    // var chromeUnblock = 'Settings/advanced settings/Privacy/Content Settings/Notifications/Manage Exceptions/',
+    //     firefoxUnblock = 'Tools/Page Info/Permissions/Show Notifications';
 
     console.log('Loading Notifications Module');
 
@@ -132,17 +129,16 @@
                 // Firefox needs "close."  Chrome needs "cancel."  This should blast both to hell.
                 try {
                     temp[i].close();
-                } catch (e) { }
+                } catch (ignore) { }
                 try {
                     temp[i].cancel();
-                } catch (e2) { }
+                } catch (ignore) { }
             }
         });
 
-        var n;
         GS.notifyUser = function (message, sound) {
             if (GS.get_option('audio_notifications')) {
-                if (typeof sound !== 'undefined') {
+                if (sound !== undefined) {
                     sound.play();
                 }
             }

--- a/src/ext/quickGame.js
+++ b/src/ext/quickGame.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, maxlen: 90, es5: true, vars:true, nomen:true */
-/*global $, _, FS, GS, mtgRoom */
-
 (function () {
     "use strict";
 
@@ -8,7 +5,7 @@
     mod.dependencies = ['FS.EventDispatcher'];
     mod.load = function () {
         var loadQuickGameModule = function () {
-            var initQuickGame, createQuickGameTable;
+            var initQuickGame; //, createQuickGameTable;
 
             // Configuration
             GS.QG = GS.QG || {};
@@ -136,11 +133,11 @@
                     var mtgRoom = window.mtgRoom;
                     var conn = mtgRoom.conn;
                     var zch = mtgRoom.helpers.ZoneClassicHelper;
-                    if (typeof conn !== 'undefined' && typeof zch !== 'undefined') {
+                    if (conn !== undefined && zch !== undefined) {
                         loadQuickGameModule();
                         alreadyLoaded = true;
                     }
-                } catch (e) {}
+                } catch (ignore) {}
             }
         });
     };

--- a/src/ext/settingsDialog.js
+++ b/src/ext/settingsDialog.js
@@ -1,6 +1,3 @@
-/*jslint browser:true, devel:true, es5:true, nomen:true, forin:true, vars:true */
-/*globals $, _, angular, GS, FS, mtgRoom */
-
 (function () {
     "use strict";
     console.log('Loading Settings Dialog');
@@ -15,7 +12,7 @@
         'FS.LaunchScreen.View.Container',
         'mtgRoom.conn.connInfo',
         'GS.submitBlacklist',
-        'GS.reconcileBlacklist',
+        'GS.reconcileBlacklist'
     ];
     GS.modules.settingsDialog.load = function () {
 
@@ -315,7 +312,7 @@
             $scope.quick_game_types = [
                 {name: 'pro'},
                 {name: 'casual'},
-                {name: 'unrated'},
+                {name: 'unrated'}
             ];
             $scope.blnewpname = '';
             $scope.blnew = {
@@ -355,7 +352,9 @@
                 $scope.blnewpname = '';
             };
             $scope.cacheCommonBlacklist = function () {
-                GS.cacheCommonBlacklist($scope.so.blacklist_common, function () {});
+                GS.cacheCommonBlacklist($scope.so.blacklist_common, function () {
+                    GS.Debug('GS.cacheCommonBlacklist()');
+                });
             };
 
             $scope.$watch('so.sortkey', function () {

--- a/src/ext/sidebar.js
+++ b/src/ext/sidebar.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, es5: true, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global $, Audio, GS, Dom, mtgRoom  */
-
 (function () {
     "use strict";
 
@@ -9,27 +6,27 @@
     mod.load = function () {
         // Resize and reposition the logviewer to match the new window size
         GS.resizeSidebar = function () {
-        
+
             // Hide sidebar if disabled in options
             if (!GS.get_option('sidebar')) {
                 $('#sidebar').css('display', 'none');
             }
-        
+
             // Keep Goko play area in center
             if ($('#sidebar').css('display') === 'none') {
                 $('#goko-game').attr('style', 'left: 50% !important; margin-left: -512px !important');
                 return;
             }
-        
+
             // Move Goko play area to far left
             // Note that the usual jQuery .css() function doesn't have precendence
             // over the entries in Goko's .css files.
             $('#goko-game').attr('style', 'left: 0px !important; margin-left: 0px !important');
-        
+
             // Calculate new logviewer size and position
             var goko_w = $('#myCanvas').width();
             var w = window.innerWidth - goko_w;
-        
+
             // Resize and reposition the sidebar
             $('#sidebar').css('left', goko_w + 'px')
                          .css('width', w + 'px')
@@ -48,11 +45,11 @@
                 - ($('#vptable').is(':visible') ? $('#vptable').height() : 0)
                 - (GS.get_option('sidebar_chat') ? $('#chatdiv').height() : 0);
             $('#prettylog').css('height', logheight);
-        
+
             // Scroll to bottom of log
             $('#prettylog').scrollTop(99999999);
         };
-        
+
         // Add sidebar to GUI
         // Children: VP table, prettified log
         $('#goko-game')
@@ -60,8 +57,8 @@
                 .append($('<table>').attr('id', 'vptable'))
                 .append($('<div>').attr('id', 'prettylog'))
                 .append($('<div>').attr('id', 'chatdiv')));
-     
-     
+
+
         GS.alsoDo(Dom.LogManager, 'addLog', null, function (opt) {
             if ($('#goko-game').css('display') !== 'none') {
                 // TODO: this is excessive
@@ -69,7 +66,7 @@
                 GS.resizeSidebar();
             }
         });
-     
+
         // Hide sidebar until first game message and after any game
         // Note: also hides after any room change, but that won't hurt
         mtgRoom.conn.bind('gatewayDisconnect', function (msg) {

--- a/src/ext/speedTweak.js
+++ b/src/ext/speedTweak.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global $, _, GS, Dom */
-
 (function () {
     "use strict";
 
@@ -39,7 +36,6 @@
 
             // Apply speed factor uniformly to all animation speeds
             if (GS.get_option('speed_tweak_uniform')) {
-                var mode, prop;
                 _.each(factors, function (fac, mode) {
                     Dom.GlobalLayout.animationTimings[mode]= {
                         name: mode,

--- a/src/ext/tableState.js
+++ b/src/ext/tableState.js
@@ -1,9 +1,6 @@
-/*jslint browser: true, devel: true, indent: 4, vars: true, nomen: true, regexp: true, forin: true, white:true */
-/*global $, _, GS, FS */
-
 (function () {
     "use strict";
-    
+
     var mod = GS.modules.tableState = new GS.Module('Table State');
     mod.dependencies = ['FS.EditTableView', 'FS.DominionEditTableView'];
     mod.load = function () {
@@ -15,7 +12,7 @@
         }, function () {
             this.$tableName.val(GS.get_option('lasttablename'));
         });
-    
+
         // Cache table settings whenever a table is created manually.
         // Note that this does not trigger when automatch creates a table.
         GS.alsoDo(FS.DominionEditTableView, 'onClickCreateTable', function () {

--- a/src/ext/utils.js
+++ b/src/ext/utils.js
@@ -1,6 +1,3 @@
-/*jslint browser: true, devel: true, indent: 4, es5: true, vars: true, nomen: true, regexp: true, forin: true */
-/*globals $, GS, mtgRoom */
-
 (function () {
     "use strict";
 
@@ -28,7 +25,7 @@
         object.prototype[methodname] = function () {
 
             // Run fnBefore
-            if (typeof fnBefore !== 'undefined' && fnBefore !== null) {
+            if (fnBefore !== undefined && fnBefore !== null) {
                 fnBefore.apply(this, arguments);
             }
 
@@ -36,7 +33,7 @@
             var out = this[methodname_o].apply(this, arguments);
 
             // Run fnAfter
-            if (typeof fnAfter !== 'undefined' && fnAfter !== null) {
+            if (fnAfter !== undefined && fnAfter !== null) {
                 fnAfter.apply(this, arguments);
             }
 
@@ -58,7 +55,7 @@
     };
 
     GS.getGameClient = function () {
-        if (typeof mtgRoom !== 'undefined') {
+        if (mtgRoom !== undefined) {
             var roomId;
             if (mtgRoom.getCurrentTable() !== null) {
                 roomId = mtgRoom.getCurrentTable().get('room').get('roomId');
@@ -66,22 +63,21 @@
                 roomId = mtgRoom.currentRoomId;
             }
 
-            if (typeof roomId === 'undefined' || roomId === null) {
+            if (roomId === undefined || roomId === null) {
                 throw 'Could not determine room id';
-            } else {
-                var table = mtgRoom.getCurrentTable();
-                var tableNo = table !== null ? table.get('number') : 0;
-                var key = roomId + ':' + tableNo;
-                return mtgRoom.games[key];
             }
+            var table = mtgRoom.getCurrentTable();
+            var tableNo = table !== null ? table.get('number') : 0;
+            var key = roomId + ':' + tableNo;
+            return mtgRoom.games[key];
         }
         throw 'Meeting Room undefined';
     };
 
     GS.sendRoomChat = function (message, nocheck) {
-        if (typeof GS.vp.toggle !== 'undefined'
+        if (GS.vp.toggle !== undefined
                 && GS.vp.toggle.isChatCommand(message)
-                && (typeof nocheck === 'undefined' || !nocheck)) {
+                && (nocheck === undefined || !nocheck)) {
             GS.vp.toggle.handleChatCommand(message);
         } else {
             var gc = GS.getGameClient();
@@ -151,10 +147,11 @@
     // load templates from the generated templates.js
     GS.template = function (templateName, options) {
       try {
-          return window['JST'][templateName](options);
+          return window.JST[templateName](options);
       } catch (e) {
           GS.debug('Template not found: ' + templateName);
           return '';
       }
-    }
+    };
+
 }());

--- a/src/ext/vpcalculator.js
+++ b/src/ext/vpcalculator.js
@@ -1,6 +1,3 @@
-/*jslint vars:true, nomen:true, forin:true, regexp:true */
-/*globals _, GS, FS */
-
 (function () {
     "use strict";
 
@@ -62,7 +59,7 @@
         // Sum of card VP values and vp tokens
         GS.vp.getVPTotal = function (pname) {
             var deck = GS.cardCounts[pname];
-            if (typeof deck === 'undefined') { return 0; }
+            if (deck === undefined) { return 0; }
             if (Object.keys(deck).length === 0) { return 0; }
             return _.keys(deck).map(function (card) {
                 return cardVPValue(card, deck) * deck[card];

--- a/src/ext/vpcounterui.js
+++ b/src/ext/vpcounterui.js
@@ -1,6 +1,3 @@
-/*jslint vars:true, nomen:true, forin:true, regexp:true, browser:true */
-/*globals $, _, angular, GS, FS */
-
 (function () {
     "use strict";
 

--- a/src/ext/vptoggle.js
+++ b/src/ext/vptoggle.js
@@ -1,6 +1,3 @@
-/*jslint vars:true, nomen:true, forin:true, regexp:true, browser:true, devel:true */
-/*globals _, $, GS, FS, mtgRoom */
-
 // TODO: Immediately send Turn 2 messages when opponents have all joined the game.
 
 (function () {
@@ -25,7 +22,7 @@
            + 'says #vpoff, or if all players have said #vpon, or if the host '
            + 'has announced it in advance by putting #vpon or #vpoff in the '
            + 'game title.');
-    
+
     GS.VPToggle = function (always_request, always_refuse, gameTitle, myName, pnames, isBots) {
         this.always_request = always_request;
         this.always_refuse = always_refuse;
@@ -82,7 +79,7 @@
             this.amLocked = false;  // If locked becasue of automatch settings,
                                     // we'll need to account for cross-version
                                     // incompatibilities
-            
+
             if (this.isMultiplayer()) {
                 if (GS.get_option('greeting').length > 0) {
                     GS.sendRoomChat(GS.get_option('greeting'));
@@ -98,8 +95,8 @@
                 GS.showRoomChat('The VP Counter is ON because all the other '
                               + 'players are bots.');
                 GS.showRoomChat('Say "#vphelp" for more info.');
-            } else if (typeof GS.AM !== 'undefined'
-                    && typeof GS.AM.vpcounter !== 'undefined'
+            } else if (GS.AM !== undefined
+                    && GS.AM.vpcounter !== undefined
                     && GS.AM.vpcounter !== null) {   // Needless caution
                 this.vpon = GS.AM.vpcounter;
                 this.locked = true;
@@ -440,7 +437,7 @@
                 onFirstAddLog();
                 firstLogReceived = true;
             }
-            if (typeof data.text === 'undefined') { return; }
+            if (data.text === undefined) { return; }
 
             var m = data.text.match(/^-+ (.*): turn ([0-9]*)/);
             if (m !== null) {


### PR DESCRIPTION
The Development page on the Wiki asks developers to follow JSLint, and now a runnable task to do just that can be part of the project!
- `npm install` will download `grunt-contrib-jslint` and `grunt-contrib-watch`
- `grunt jslint` lints `Gruntfile.js` and all of the .js files in `src/ext/`
- no more duplicating JSLint directives in comments at the top of files; all the configuration is set in `Gruntfile.js`
- `grunt watch:jslint` will start a process to watch for file changes and automatically run `grunt jslint`
