### PR TITLE
Use port 443 for all secure http and wss

### DIFF
--- a/src/ext/automatch.js
+++ b/src/ext/automatch.js
@@ -20,11 +20,10 @@
             GS.AM.wsMaxFails = 100;
 
             // Use secure websockets
-            // TODO: switch from 8889 back to 443 port after transition
             if (GS.get_option('testmode')) {
-                GS.AM.server_url = 'wss://gokosalvager.com:7889/automatch';
+                GS.AM.server_url = 'wss://gokosalvager.com:7443/automatch';
             } else {
-                GS.AM.server_url = 'wss://gokosalvager.com:8889/automatch';
+                GS.AM.server_url = 'wss://gokosalvager.com:443/automatch';
             }
 
             // Initial state

--- a/src/ext/avatarUpload.js
+++ b/src/ext/avatarUpload.js
@@ -61,7 +61,7 @@
         $('#auButton').on("click", function () {
             $('#auPID').val(mtgRoom.conn.connInfo.playerId);
             $.ajax({
-                url: 'https://www.gokosalvager.com:8889/gs/submit_avatar',
+                url: 'https://www.gokosalvager.com:443/gs/submit_avatar',
                 type: 'POST',
                 xhr: function () { return $.ajaxSettings.xhr(); },
                 beforeSend: null,

--- a/src/ext/avatars.js
+++ b/src/ext/avatars.js
@@ -38,8 +38,7 @@
                 callback(img);
             };
             img.crossOrigin = "Anonymous";
-            // TODO: Switch from port 8889 back to 443 after server transition
-            img.src = "https://gokosalvager.com:8889/"
+            img.src = "https://gokosalvager.com:443/"
                     + "gs/avatars/" + userdata.player.id + ".jpg";
         };
 

--- a/src/ext/connection.js
+++ b/src/ext/connection.js
@@ -27,8 +27,7 @@
         // Connection variables
         GS.WS = {};
         GS.WS.domain = 'gokosalvager.com';
-        GS.WS.port = 8889;  // TODO: Switch from port 8889 back to 443 after
-                            //       server transition
+        GS.WS.port = 443;
         GS.WS.url = "wss://" + GS.WS.domain + ":" + GS.WS.port + "/gs/websocket";
         GS.WS.noreconnect = false;
         GS.WS.maxFails = 36;


### PR DESCRIPTION
I was sure I'd fixed this before, but apparently not.  Everything Salvager does to communicate with gokosalvager.com is now secure (https or wss) and using port 443.

Previously, it had been using the arbitrarily-chosen 8889 because the server was identifying itself as andrewiannaccone.com for SSL on prot 443.
