### PR TITLE
Use proper HTML5 API for all browsers

### DIFF
--- a/src/ext/notifications.js
+++ b/src/ext/notifications.js
@@ -8,49 +8,31 @@
         '#desktopnotificationcheckbox'
     ];
     GS.modules.notifications.load = function () {
+        var Notification = window.Notification || window.mozNotification
+                                               || window.webkitNotification;
+
         var openNotifications = [];
 
         var requestNotificationPermission = function () {
-            switch (GS.getBrowser()) {
-            case 'Firefox':
-                Notification.requestPermission();
-                break;
-            case 'Chrome':
-                window.webkitNotifications.requestPermission();
-                break;
-            case 'Safari':
-                GS.set_option('desktop_notifications', false);
-                $('#settingsDialog').scope().$digest();
-                alert('Sorry. Safari does not support HTML5 desktop notifications yet.');
-                break;
-            default:
-                throw 'Unknown browser ' + GS.getBrowser();
-            }
+            Notification.requestPermission(function (p) {
+                console.log('Notification permission: ' + p);
+            });
         };
 
         var ALLOWED = 0;
         var NOT_SET = 1;
         var BLOCKED = 2;
         var getNotificationPermission = function () {
-            switch (GS.getBrowser()) {
-            case 'Firefox':
-                switch (Notification.permission) {
-                case 'granted':
-                    return 0;
-                case 'default':
-                    return 1;
-                case 'denied':
-                    return 2;
-                default:
-                    throw 'Impossible Firefox Notification.permission value: '
-                        + Notification.permission;
-                }
-            case 'Chrome':
-                return window.webkitNotifications.checkPermission();
-            case 'Safari':
+            switch (Notification.permission) {
+            case 'granted':
+                return 0;
+            case 'default':
                 return 1;
+            case 'denied':
+                return 2;
             default:
-                throw 'Unknown browser ' + GS.getBrowser();
+                throw 'Impossible Notification.permission value: '
+                    + Notification.permission;
             }
         };
 
@@ -99,23 +81,8 @@
         });
 
         var createDesktopNotification = function (message) {
-            var n;
-            switch (GS.getBrowser()) {
-            case 'Firefox':
-                n = new Notification(message, {icon: GS.salvagerIconURL});
-                openNotifications.push(n);
-                break;
-            case 'Chrome':
-                n = window.webkitNotifications.createNotification(GS.salvagerIconURL,
-                        'Goko Salvager', message);
-                n.show();
-                openNotifications.push(n);
-                break;
-            case 'Safari':
-                throw 'Impossible to reach this code.';
-            default:
-                throw 'Unknown browser ' + GS.getBrowser();
-            }
+            var n = new Notification(message, {icon: GS.salvagerIconURL});
+            openNotifications.push(n);
         };
 
         // Close notifications whenever user clicks anywhere

--- a/src/ext/utils.js
+++ b/src/ext/utils.js
@@ -106,7 +106,7 @@
         return out;
     };
 
-    GS.salvagerIconURL = 'http://gokologs.drunkensailor.org/static/img/salvager128.png';
+    GS.salvagerIconURL = 'https://www.gokosalvager.com/static/img/salvager128.png';
     GS.url = 'www.gokosalvager.com';
 
     // Parse numbers like 303 and 4.23k


### PR DESCRIPTION
Fixes #234.  Chrome, Firefox, Safari, and Chromium all now conform to the same HTML5 Notifications API.  This commit make Salvager use them all in the same way.

Also fixed the URL for the Salvager icon that was causing Kaspersky to freak out.  It was still fetching it from drunkensailor.org.

I've tested both the notification creation and the notification permission requesting on:
- Chromium 33 on Arch Linux
- Firefox 26 on Arch Linux
- Chrome 35 on OSX Mavericks
- Safari 7 on OSX Mavericks
- Chrome 35 on Windows 7

I also haven't tested on older versions of the browsers, but they've each been properly supporting the HTML5 Notification draft spec for a while now, so we should be okay there.

This is a high-priority fix, since it's preventing opponents from joining games for everyone who uses Chrome and who has recently updated to Chrome 35.  I'll deploy it (along with the rest of the current beta) as an official release as soon as someone tests and merges it.
